### PR TITLE
Migrate Asset Photos to MinIO and Fix Frontend Cache

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,3 +19,13 @@ SESSION_DRIVER=cookie
 # CORS (configure allowed origins for API access)
 #--------------------------------------------------------------------
 CORS_ORIGIN=http://localhost:3000
+
+#--------------------------------------------------------------------
+# MinIO (S3-compatible Object Storage)
+#--------------------------------------------------------------------
+MINIO_ENDPOINT=your-minio-host.example.com
+MINIO_PORT=9000
+MINIO_ACCESS_KEY=your-access-key
+MINIO_SECRET_KEY=your-secret-key
+MINIO_USE_SSL=false
+MINIO_BUCKET=your-bucket-name

--- a/backend/app/controllers/item_photos_controller.ts
+++ b/backend/app/controllers/item_photos_controller.ts
@@ -1,17 +1,16 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import ItemPhoto from '#models/item_photo'
-import fs from 'node:fs'
-import app from '@adonisjs/core/services/app'
-import { join } from 'node:path'
+import minioService from '#services/minio_service'
 
 export default class ItemPhotosController {
   async destroy({ params, response }: HttpContext) {
     const photo = await ItemPhoto.findOrFail(params.id)
 
-    // Delete file from disk
-    const filePath = join(app.publicPath(), photo.photoUrl)
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath)
+    // Hapus file dari MinIO
+    try {
+      await minioService.deleteFile(photo.photoUrl)
+    } catch (error) {
+      console.warn('Warning: Could not delete file from MinIO:', error.message)
     }
 
     await photo.delete()

--- a/backend/app/controllers/items_controller.ts
+++ b/backend/app/controllers/items_controller.ts
@@ -1,9 +1,51 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import Item from '#models/item'
-import app from '@adonisjs/core/services/app'
-import { randomUUID } from 'node:crypto'
+import minioService from '#services/minio_service'
+import { readFile } from 'node:fs/promises'
 
 export default class ItemsController {
+  /**
+   * Serialize items with presigned URLs for photos
+   */
+  private async serializeWithSignedUrls(items: Item[]) {
+    const result = []
+
+    for (const item of items) {
+      const itemJson = item.toJSON()
+
+      if (itemJson.photos && itemJson.photos.length > 0) {
+        itemJson.photos = await Promise.all(
+          itemJson.photos.map(async (photo: any) => ({
+            ...photo,
+            signedUrl: await minioService.getPresignedUrl(photo.photoUrl),
+          }))
+        )
+      }
+
+      result.push(itemJson)
+    }
+
+    return result
+  }
+
+  /**
+   * Serialize a single item with presigned URLs for photos
+   */
+  private async serializeItemWithSignedUrls(item: Item) {
+    const itemJson = item.toJSON()
+
+    if (itemJson.photos && itemJson.photos.length > 0) {
+      itemJson.photos = await Promise.all(
+        itemJson.photos.map(async (photo: any) => ({
+          ...photo,
+          signedUrl: await minioService.getPresignedUrl(photo.photoUrl),
+        }))
+      )
+    }
+
+    return itemJson
+  }
+
   /**
    * Display a list of resource
    */
@@ -25,7 +67,9 @@ export default class ItemsController {
     }
 
     const items = await query
-    return response.ok(items)
+    const serialized = await this.serializeWithSignedUrls(items)
+
+    return response.ok(serialized)
   }
 
   /**
@@ -51,17 +95,20 @@ export default class ItemsController {
 
     for (const photo of photos) {
       if (photo.isValid) {
-        await photo.move(app.publicPath('uploads'), {
-          name: `${randomUUID()}.${photo.extname}`,
-        })
+        const fileBuffer = await readFile(photo.tmpPath!)
+        const contentType = photo.contentType || 'image/jpeg'
+        
+        const objectKey = await minioService.uploadFile(fileBuffer, photo.clientName, contentType)
+        
         await item.related('photos').create({
-          photoUrl: `/uploads/${photo.fileName}`,
+          photoUrl: objectKey,
         })
       }
     }
 
     await item.load('photos')
-    return response.created(item)
+    const serialized = await this.serializeItemWithSignedUrls(item)
+    return response.created(serialized)
   }
 
   /**
@@ -74,7 +121,9 @@ export default class ItemsController {
       .preload('folder')
       .preload('category')
       .firstOrFail()
-    return response.ok(item)
+
+    const serialized = await this.serializeItemWithSignedUrls(item)
+    return response.ok(serialized)
   }
 
   /**
@@ -102,17 +151,20 @@ export default class ItemsController {
 
     for (const photo of photos) {
       if (photo.isValid) {
-        await photo.move(app.publicPath('uploads'), {
-          name: `${randomUUID()}.${photo.extname}`,
-        })
+        const fileBuffer = await readFile(photo.tmpPath!)
+        const contentType = photo.contentType || 'image/jpeg'
+        
+        const objectKey = await minioService.uploadFile(fileBuffer, photo.clientName, contentType)
+
         await item.related('photos').create({
-          photoUrl: `/uploads/${photo.fileName}`,
+          photoUrl: objectKey,
         })
       }
     }
 
     await item.load('photos')
-    return response.ok(item)
+    const serialized = await this.serializeItemWithSignedUrls(item)
+    return response.ok(serialized)
   }
 
   /**
@@ -120,7 +172,23 @@ export default class ItemsController {
    */
   async destroy({ params, response }: HttpContext) {
     const item = await Item.findOrFail(params.id)
+
+    // Load and delete all photos from MinIO first
+    await item.load('photos')
+
+    for (const photo of item.photos) {
+      try {
+        await minioService.deleteFile(photo.photoUrl)
+      } catch (error) {
+        console.warn('Warning: Could not delete photo from MinIO:', error.message)
+      }
+    }
+
+    // Delete the item (cascading delete will remove photo records if configured,
+    // otherwise delete them manually)
+    await item.related('photos').query().delete()
     await item.delete()
+
     return response.noContent()
   }
-}
+}

--- a/backend/app/services/minio_service.ts
+++ b/backend/app/services/minio_service.ts
@@ -1,0 +1,88 @@
+import * as Minio from 'minio'
+import env from '#start/env'
+import { randomUUID } from 'node:crypto'
+
+class MinioService {
+  private client: Minio.Client
+  private bucket: string
+
+  constructor() {
+    this.client = new Minio.Client({
+      endPoint: env.get('MINIO_ENDPOINT'),
+      port: env.get('MINIO_PORT'),
+      useSSL: env.get('MINIO_USE_SSL'),
+      accessKey: env.get('MINIO_ACCESS_KEY'),
+      secretKey: env.get('MINIO_SECRET_KEY'),
+    })
+    this.bucket = env.get('MINIO_BUCKET')
+  }
+
+  /**
+   * Upload file ke MinIO
+   * @param fileBuffer - Buffer dari file yang diupload
+   * @param originalName - Nama file asli (untuk mendapatkan extension)
+   * @param contentType - MIME type file (contoh: 'image/jpeg')
+   * @returns Object key (path) file di MinIO
+   */
+  async uploadFile(fileBuffer: Buffer, originalName: string, contentType: string): Promise<string> {
+    const ext = originalName.split('.').pop()
+    const objectKey = `uploads/${randomUUID()}.${ext}`
+
+    await this.client.putObject(this.bucket, objectKey, fileBuffer, fileBuffer.length, {
+      'Content-Type': contentType,
+    })
+
+    return objectKey
+  }
+
+  /**
+   * Generate presigned URL untuk mengakses file
+   * @param objectKey - Key/path file di MinIO
+   * @param expirySeconds - Waktu kedaluwarsa URL (default: 7 hari)
+   * @returns Presigned URL
+   */
+  async getPresignedUrl(objectKey: string, expirySeconds: number = 7 * 24 * 60 * 60): Promise<string> {
+    // Check if objectKey is already a full URL (legacy or external)
+    if (objectKey.startsWith('http')) {
+      return objectKey
+    }
+    
+    // Check if it's a local path (legacy) — generate full URL to backend
+    if (objectKey.startsWith('/uploads/')) {
+      return `${env.get('APP_URL')}${objectKey}`
+    }
+
+    try {
+      return await this.client.presignedGetObject(this.bucket, objectKey, expirySeconds)
+    } catch (error) {
+      console.error('Error generating presigned URL:', error)
+      return objectKey // Fallback
+    }
+  }
+
+  /**
+   * Hapus file dari MinIO
+   * @param objectKey - Key/path file di MinIO
+   */
+  async deleteFile(objectKey: string): Promise<void> {
+    if (objectKey.startsWith('http') || objectKey.startsWith('/uploads/')) {
+        return
+    }
+    await this.client.removeObject(this.bucket, objectKey)
+  }
+
+  /**
+   * Cek apakah file ada di MinIO
+   * @param objectKey - Key/path file di MinIO
+   */
+  async fileExists(objectKey: string): Promise<boolean> {
+    try {
+      await this.client.statObject(this.bucket, objectKey)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+export default new MinioService()

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "@vinejs/vine": "^4.3.0",
         "better-sqlite3": "^12.8.0",
         "luxon": "^3.7.2",
+        "minio": "^8.0.7",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
@@ -1345,6 +1346,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2463,6 +2476,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -2576,6 +2595,15 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/block-stream2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-2.1.0.tgz",
+      "integrity": "sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2601,6 +2629,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-or-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
+      "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
@@ -2658,6 +2692,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/builtin-modules": {
@@ -3158,6 +3201,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
@@ -3779,6 +3831,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -3885,6 +3943,42 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -3986,6 +4080,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/find-cache-directory": {
@@ -5299,6 +5402,60 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minio": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minio/-/minio-8.0.7.tgz",
+      "integrity": "sha512-E737MgufW8CeQAsTAtnEMrxZ9scMSf29kkhZoXzDTKj/Jszzo2SfeZUH9wbDQH2Rsq6TCtl/yQL0+XdVKZansQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.4",
+        "block-stream2": "^2.1.0",
+        "browser-or-node": "^2.1.1",
+        "buffer-crc32": "^1.0.0",
+        "eventemitter3": "^5.0.1",
+        "fast-xml-parser": "^5.3.4",
+        "ipaddr.js": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
+        "query-string": "^7.1.3",
+        "stream-json": "^1.8.0",
+        "through2": "^4.0.2",
+        "xml2js": "^0.5.0 || ^0.6.2"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/minio/node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/minio/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minio/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -5625,6 +5782,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -5960,6 +6132,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/queue-microtask": {
@@ -6320,6 +6510,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -6679,6 +6878,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -6695,6 +6903,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -6819,6 +7051,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -6977,6 +7221,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tildify": {
@@ -7440,6 +7693,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yargs-parser": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -68,6 +68,7 @@
     "@vinejs/vine": "^4.3.0",
     "better-sqlite3": "^12.8.0",
     "luxon": "^3.7.2",
+    "minio": "^8.0.7",
     "reflect-metadata": "^0.2.2"
   },
   "hotHook": {

--- a/backend/start/env.ts
+++ b/backend/start/env.ts
@@ -30,4 +30,12 @@ export default await Env.create(new URL('../', import.meta.url), {
 
   // CORS
   CORS_ORIGIN: Env.schema.string.optional(),
+
+  // MinIO
+  MINIO_ENDPOINT: Env.schema.string(),
+  MINIO_PORT: Env.schema.number(),
+  MINIO_ACCESS_KEY: Env.schema.string(),
+  MINIO_SECRET_KEY: Env.schema.string(),
+  MINIO_USE_SSL: Env.schema.boolean(),
+  MINIO_BUCKET: Env.schema.string(),
 })

--- a/frontend/src/app/[lang]/(dashboard)/(private)/apps/categories/page.jsx
+++ b/frontend/src/app/[lang]/(dashboard)/(private)/apps/categories/page.jsx
@@ -11,7 +11,8 @@ const getCategoriesData = async (accessToken) => {
   const res = await fetch(`${process.env.API_URL}/categories`, {
     headers: {
       Authorization: `Bearer ${accessToken}`
-    }
+    },
+    cache: 'no-store'
   })
 
   if (!res.ok) {

--- a/frontend/src/app/[lang]/(dashboard)/(private)/apps/folders/page.jsx
+++ b/frontend/src/app/[lang]/(dashboard)/(private)/apps/folders/page.jsx
@@ -11,7 +11,8 @@ const getFoldersData = async (accessToken) => {
   const res = await fetch(`${process.env.API_URL}/folders`, {
     headers: {
       Authorization: `Bearer ${accessToken}`
-    }
+    },
+    cache: 'no-store'
   })
 
   if (!res.ok) {

--- a/frontend/src/app/[lang]/(dashboard)/(private)/apps/items/page.jsx
+++ b/frontend/src/app/[lang]/(dashboard)/(private)/apps/items/page.jsx
@@ -11,7 +11,8 @@ const getData = async (accessToken, endpoint) => {
   const res = await fetch(`${process.env.API_URL}/${endpoint}`, {
     headers: {
       Authorization: `Bearer ${accessToken}`
-    }
+    },
+    cache: 'no-store'
   })
 
   if (!res.ok) {

--- a/frontend/src/views/apps/items/ItemCard.jsx
+++ b/frontend/src/views/apps/items/ItemCard.jsx
@@ -35,7 +35,7 @@ const ItemCard = ({ item, onUpdate, onEdit }) => {
   }
 
   const mainPhoto = item.photos && item.photos.length > 0 
-    ? `${process.env.NEXT_PUBLIC_API_URL.replace('/api/v1', '')}${item.photos[0].photoUrl}` 
+    ? item.photos[0].signedUrl
     : 'https://placehold.co/600x400?text=No+Image'
 
   return (

--- a/issue.md
+++ b/issue.md
@@ -1,66 +1,410 @@
-# Issue: Migrasi Fitur Manajemen Aset dari Frontend Lama ke Frontend Baru
+# Issue: Migrasi Penyimpanan Foto dari Local Filesystem ke MinIO Object Storage
 
 ## Konteks
-Kita telah membeli template frontend baru (Next.js dengan MUI) yang berada di folder `frontend-new`. Integrasi fitur login dan autentikasi dengan backend AdonisJS **sudah selesai dilakukan**.
-Saat ini, kita perlu memigrasikan fitur-fitur manajemen aset utama yang sudah ada di folder `frontend` (React biasa) ke dalam arsitektur template baru di `frontend-new`.
+
+Saat ini, backend AdonisJS menyimpan file foto item di folder `public/uploads/` pada server lokal.
+Foto diakses melalui static file serving AdonisJS (`@adonisjs/static`).
+
+Pendekatan ini memiliki beberapa kelemahan:
+- File hilang saat re-deploy atau pindah server
+- Tidak scalable untuk multi-instance deployment
+- Tidak ada CDN/caching layer
+- Bergantung pada disk space server
+
+Kita akan memigrasikan penyimpanan foto ke **MinIO** (S3-compatible object storage) yang sudah tersedia di server.
 
 ## Tujuan
-Memigrasikan fungsi CRUD (Create, Read, Update, Delete) untuk **Folders**, **Categories**, dan **Items** agar sesuai dengan desain dan standar kode pada template baru (`frontend-new`), serta terhubung dengan benar ke backend API.
 
-## Referensi Kode Lama
-Silakan jadikan komponen-komponen di folder `frontend/src/components` sebagai acuan logika bisnis dan request API:
-- `FolderModal.js`
-- `CategoryModal.js`
-- `ItemCard.js`
-- `ItemModal.js`
-- `MainContent.js`
-- `Sidebar.js`
+Mengubah mekanisme upload dan penyimpanan foto dari lokal filesystem (`public/uploads/`) ke MinIO object storage, sehingga:
+1. Foto disimpan di MinIO bucket `shefly-password`
+2. Foto diakses via presigned URL atau public URL dari MinIO
+3. Operasi hapus foto juga menghapus file dari MinIO
+4. Database `item_photos.photoUrl` menyimpan key/path MinIO, bukan path lokal
 
-## Detail Implementasi (Langkah-langkah)
+## Prasyarat
 
-### 1. Pahami Arsitektur Template Baru (`frontend-new`)
-- Template baru menggunakan **Next.js App Router** (`src/app`).
-- UI menggunakan komponen **Material UI (MUI)**.
-- Autentikasi ditangani oleh **NextAuth**.
-- Untuk mengambil data yang membutuhkan autentikasi (token JWT), ambil `accessToken` dari session pengguna.
-- Struktur folder biasanya memisahkan **routing** (`src/app/[lang]/(dashboard)/(private)/apps/...`) dan **view components** (`src/views/apps/...`).
+### ✅ Sudah Selesai
+- [x] Package `minio` sudah terinstall di backend (`npm install minio`)
+- [x] Environment variables MinIO sudah ditambahkan ke `.env` dan `.env.example`
+- [x] Validasi env vars sudah ditambahkan di `start/env.ts`
+- [x] Bucket `shefly-password` sudah dibuat di MinIO server
+- [x] Koneksi ke MinIO sudah diverifikasi dan berfungsi
 
-### 2. Implementasi Manajemen Folders
-- Halaman route: `src/app/[lang]/(dashboard)/(private)/apps/folders/page.jsx` (Sebagian sudah dibuat, silakan lanjutkan).
-- View component: `src/views/apps/folders/...`
-- **Fitur yang dibutuhkan:**
-  - Tampilkan daftar folder (fetch dari `GET /api/v1/folders`).
-  - Tambah folder baru (Form/Modal untuk `POST /api/v1/folders`).
-  - Edit folder (`PUT /api/v1/folders/:id`).
-  - Hapus folder (`DELETE /api/v1/folders/:id`).
+### Environment Variables (sudah ada di `.env`)
+```env
+MINIO_ENDPOINT=server.hafiyyanabdulaziz.my.id
+MINIO_PORT=9002
+MINIO_ACCESS_KEY=hafiyyanabdulaziz
+MINIO_SECRET_KEY=MICROSOFTsaya1!
+MINIO_USE_SSL=false
+MINIO_BUCKET=shefly-password
+```
 
-### 3. Implementasi Manajemen Categories
-- Buat halaman route: `src/app/[lang]/(dashboard)/(private)/apps/categories/page.jsx`.
-- Buat view component: `src/views/apps/categories/...`
-- **Fitur yang dibutuhkan:**
-  - Tampilkan daftar kategori (fetch dari `GET /api/v1/categories`).
-  - Tambah kategori baru (`POST /api/v1/categories`).
-  - Edit kategori (`PUT /api/v1/categories/:id`).
-  - Hapus kategori (`DELETE /api/v1/categories/:id`).
+## Detail Implementasi (Step-by-Step)
 
-### 4. Implementasi Manajemen Items
-- Buat halaman route: `src/app/[lang]/(dashboard)/(private)/apps/items/page.jsx`.
-- Buat view component: `src/views/apps/items/...`
-- **Fitur yang dibutuhkan:**
-  - Tampilkan daftar item (fetch dari `GET /api/v1/items`).
-  - Tambah item baru beserta foto (`POST /api/v1/items`). Perhatikan cara _upload_ file/foto jika ada.
-  - Edit detail item (`PUT /api/v1/items/:id`).
-  - Hapus item (`DELETE /api/v1/items/:id`).
-  - Hapus foto spesifik pada item (`DELETE /api/v1/item-photos/:id`).
+### Step 1: Buat MinIO Service (`app/services/minio_service.ts`)
 
-### 5. Penyesuaian API Request
-- Pastikan semua HTTP request (fetch/axios) menyertakan header `Authorization: Bearer <accessToken>`.
-- `accessToken` bisa didapatkan dari session (misalnya dengan `useSession` di _client component_ atau `getServerSession(authOptions)` di _server component_).
-- Base URL API harus menggunakan variabel `process.env.NEXT_PUBLIC_API_URL`.
+Buat file service baru yang mengenkapsulasi semua interaksi dengan MinIO.
 
-## Panduan UI/UX
-- Gunakan komponen bawaan MUI yang tersedia di template (misalnya `Table`, `Card`, `Dialog`/Modal, `TextField`, `Button`).
-- Jangan buat _styling_ mentah dari awal jika ada komponen template yang bisa didaur ulang.
-- Tampilkan notifikasi (misalnya Toast/Snackbar atau `Alert`) saat operasi berhasil atau gagal.
+**File:** `backend/app/services/minio_service.ts`
 
-tolong lakukan testing dan pastikan tidak ada error.
+```typescript
+import * as Minio from 'minio'
+import env from '#start/env'
+import { randomUUID } from 'node:crypto'
+
+class MinioService {
+  private client: Minio.Client
+  private bucket: string
+
+  constructor() {
+    this.client = new Minio.Client({
+      endPoint: env.get('MINIO_ENDPOINT'),
+      port: env.get('MINIO_PORT'),
+      useSSL: env.get('MINIO_USE_SSL'),
+      accessKey: env.get('MINIO_ACCESS_KEY'),
+      secretKey: env.get('MINIO_SECRET_KEY'),
+    })
+    this.bucket = env.get('MINIO_BUCKET')
+  }
+
+  /**
+   * Upload file ke MinIO
+   * @param fileBuffer - Buffer dari file yang diupload
+   * @param originalName - Nama file asli (untuk mendapatkan extension)
+   * @param contentType - MIME type file (contoh: 'image/jpeg')
+   * @returns Object key (path) file di MinIO
+   */
+  async uploadFile(fileBuffer: Buffer, originalName: string, contentType: string): Promise<string> {
+    const ext = originalName.split('.').pop()
+    const objectKey = `uploads/${randomUUID()}.${ext}`
+
+    await this.client.putObject(this.bucket, objectKey, fileBuffer, fileBuffer.length, {
+      'Content-Type': contentType,
+    })
+
+    return objectKey
+  }
+
+  /**
+   * Generate presigned URL untuk mengakses file
+   * @param objectKey - Key/path file di MinIO
+   * @param expirySeconds - Waktu kedaluwarsa URL (default: 7 hari)
+   * @returns Presigned URL
+   */
+  async getPresignedUrl(objectKey: string, expirySeconds: number = 7 * 24 * 60 * 60): Promise<string> {
+    return await this.client.presignedGetObject(this.bucket, objectKey, expirySeconds)
+  }
+
+  /**
+   * Hapus file dari MinIO
+   * @param objectKey - Key/path file di MinIO
+   */
+  async deleteFile(objectKey: string): Promise<void> {
+    await this.client.removeObject(this.bucket, objectKey)
+  }
+
+  /**
+   * Cek apakah file ada di MinIO
+   * @param objectKey - Key/path file di MinIO
+   */
+  async fileExists(objectKey: string): Promise<boolean> {
+    try {
+      await this.client.statObject(this.bucket, objectKey)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+export default new MinioService()
+```
+
+**Penjelasan:**
+- Service ini di-export sebagai singleton instance
+- `uploadFile()` meng-generate unique filename dengan UUID untuk menghindari collision
+- `getPresignedUrl()` membuat URL sementara yang bisa diakses untuk melihat foto
+- File disimpan dengan prefix `uploads/` di dalam bucket
+
+---
+
+### Step 2: Ubah `items_controller.ts` — Method `store()`
+
+**File:** `backend/app/controllers/items_controller.ts`
+
+**Perubahan yang perlu dilakukan:**
+
+1. Hapus import `app` dari `@adonisjs/core/services/app` (tidak diperlukan lagi)
+2. Hapus import `randomUUID` (sudah ditangani di MinioService)
+3. Tambah import `MinioService`
+4. Ubah logika upload foto dari `photo.move()` ke `MinioService.uploadFile()`
+
+**Kode SEBELUM (baris 52-61):**
+```typescript
+for (const photo of photos) {
+  if (photo.isValid) {
+    await photo.move(app.publicPath('uploads'), {
+      name: `${randomUUID()}.${photo.extname}`,
+    })
+    await item.related('photos').create({
+      photoUrl: `/uploads/${photo.fileName}`,
+    })
+  }
+}
+```
+
+**Kode SESUDAH:**
+```typescript
+import minioService from '#services/minio_service'
+import { readFile } from 'node:fs/promises'
+
+// ... di dalam method store():
+
+for (const photo of photos) {
+  if (photo.isValid) {
+    // Baca file dari temp path
+    const fileBuffer = await readFile(photo.tmpPath!)
+    const contentType = `image/${photo.extname}`
+
+    // Upload ke MinIO
+    const objectKey = await minioService.uploadFile(fileBuffer, photo.clientName, contentType)
+
+    // Simpan object key di database
+    await item.related('photos').create({
+      photoUrl: objectKey,
+    })
+  }
+}
+```
+
+**Perbedaan utama:**
+- ❌ Sebelum: `photo.move()` → menyimpan ke folder `public/uploads/`
+- ✅ Sesudah: `readFile()` + `minioService.uploadFile()` → upload ke MinIO
+- ❌ Sebelum: `photoUrl` = `/uploads/filename.jpg` (path lokal)
+- ✅ Sesudah: `photoUrl` = `uploads/uuid.jpg` (object key MinIO)
+
+---
+
+### Step 3: Ubah `items_controller.ts` — Method `update()`
+
+Lakukan perubahan yang sama persis seperti di method `store()`.
+
+**Kode SEBELUM (baris 103-112):**
+```typescript
+for (const photo of photos) {
+  if (photo.isValid) {
+    await photo.move(app.publicPath('uploads'), {
+      name: `${randomUUID()}.${photo.extname}`,
+    })
+    await item.related('photos').create({
+      photoUrl: `/uploads/${photo.fileName}`,
+    })
+  }
+}
+```
+
+**Kode SESUDAH:**
+```typescript
+for (const photo of photos) {
+  if (photo.isValid) {
+    const fileBuffer = await readFile(photo.tmpPath!)
+    const contentType = `image/${photo.extname}`
+    const objectKey = await minioService.uploadFile(fileBuffer, photo.clientName, contentType)
+
+    await item.related('photos').create({
+      photoUrl: objectKey,
+    })
+  }
+}
+```
+
+---
+
+### Step 4: Ubah `item_photos_controller.ts` — Method `destroy()`
+
+**File:** `backend/app/controllers/item_photos_controller.ts`
+
+**Perubahan yang perlu dilakukan:**
+
+1. Hapus import `fs`, `app`, dan `join`
+2. Tambah import `MinioService`
+3. Ubah logika hapus file dari filesystem ke MinIO
+
+**Kode SEBELUM (seluruh file):**
+```typescript
+import type { HttpContext } from '@adonisjs/core/http'
+import ItemPhoto from '#models/item_photo'
+import fs from 'node:fs'
+import app from '@adonisjs/core/services/app'
+import { join } from 'node:path'
+
+export default class ItemPhotosController {
+  async destroy({ params, response }: HttpContext) {
+    const photo = await ItemPhoto.findOrFail(params.id)
+
+    // Delete file from disk
+    const filePath = join(app.publicPath(), photo.photoUrl)
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath)
+    }
+
+    await photo.delete()
+    return response.noContent()
+  }
+}
+```
+
+**Kode SESUDAH:**
+```typescript
+import type { HttpContext } from '@adonisjs/core/http'
+import ItemPhoto from '#models/item_photo'
+import minioService from '#services/minio_service'
+
+export default class ItemPhotosController {
+  async destroy({ params, response }: HttpContext) {
+    const photo = await ItemPhoto.findOrFail(params.id)
+
+    // Hapus file dari MinIO
+    try {
+      await minioService.deleteFile(photo.photoUrl)
+    } catch (error) {
+      console.warn('Warning: Could not delete file from MinIO:', error.message)
+    }
+
+    await photo.delete()
+    return response.noContent()
+  }
+}
+```
+
+---
+
+### Step 5: Tambah Endpoint Baru untuk Mengambil Presigned URL
+
+Karena foto sekarang disimpan di MinIO (bukan public folder), frontend perlu cara untuk mendapatkan URL foto yang bisa diakses.
+
+**Opsi A (Recommended): Tambah computed property di Model**
+
+Buat endpoint baru atau modifikasi response agar menyertakan presigned URL.
+
+**Cara yang paling simpel:** Buat endpoint baru untuk mendapatkan URL foto.
+
+**Tambah di `routes.ts`:**
+```typescript
+router.get('item-photos/:id/url', '#controllers/item_photos_controller.getUrl')
+```
+
+**Tambah method baru di `item_photos_controller.ts`:**
+```typescript
+async getUrl({ params, response }: HttpContext) {
+  const photo = await ItemPhoto.findOrFail(params.id)
+  const url = await minioService.getPresignedUrl(photo.photoUrl)
+  return response.ok({ url })
+}
+```
+
+**Opsi B (Lebih Simpel): Tambah photo URL di items response**
+
+Ubah `items_controller.ts` agar setelah load photos, tambahkan presigned URL ke setiap foto.
+
+**Di method `index()`, `show()`, `store()`, dan `update()`**, setelah query items, generate presigned URLs:
+
+```typescript
+// Setelah mendapatkan items/item:
+for (const item of items) {
+  for (const photo of item.photos) {
+    photo.$extras.signedUrl = await minioService.getPresignedUrl(photo.photoUrl)
+  }
+}
+```
+
+Atau buat **transformer/serializer** yang otomatis menambahkan URL.
+
+> **⚠️ PENTING:** Pilih salah satu opsi. Opsi B lebih simpel dan tidak memerlukan perubahan frontend yang banyak, tapi presigned URL akan selalu di-generate meskipun tidak dibutuhkan.
+
+---
+
+### Step 6: Update Frontend (`ItemCard.jsx`)
+
+**File:** `frontend/src/views/apps/items/ItemCard.jsx`
+
+**Perubahan tergantung opsi yang dipilih di Step 5.**
+
+**Jika Opsi B (presigned URL di items response):**
+
+```jsx
+// SEBELUM (baris 37-39):
+const mainPhoto = item.photos && item.photos.length > 0 
+  ? `${process.env.NEXT_PUBLIC_API_URL.replace('/api/v1', '')}${item.photos[0].photoUrl}` 
+  : 'https://placehold.co/600x400?text=No+Image'
+
+// SESUDAH:
+const mainPhoto = item.photos && item.photos.length > 0 
+  ? item.photos[0].$extras?.signedUrl || item.photos[0].signedUrl
+  : 'https://placehold.co/600x400?text=No+Image'
+```
+
+**Jika Opsi A (endpoint terpisah):**
+Frontend perlu fetch URL foto secara terpisah via `GET /api/v1/item-photos/:id/url`.
+
+---
+
+### Step 7: (Opsional) Migrasi Foto Lama
+
+Jika ada foto lama di `public/uploads/` yang perlu dipindahkan ke MinIO, buat script migrasi:
+
+**File:** `backend/commands/migrate_photos_to_minio.ts` (AdonisJS Ace Command)
+
+```typescript
+// Pseudocode:
+// 1. Query semua ItemPhoto dari database
+// 2. Untuk setiap foto yang path-nya masih berupa path lokal (dimulai dengan /uploads/):
+//    a. Baca file dari public/uploads/
+//    b. Upload ke MinIO
+//    c. Update photoUrl di database dengan object key baru
+// 3. (Opsional) Hapus file lokal setelah migrasi berhasil
+```
+
+---
+
+## Checklist Implementasi
+
+- [ ] Buat `app/services/minio_service.ts`
+- [ ] Update import di `items_controller.ts` (hapus `app`, `randomUUID`; tambah `minioService`, `readFile`)
+- [ ] Ubah method `store()` di `items_controller.ts`
+- [ ] Ubah method `update()` di `items_controller.ts`
+- [ ] Ubah `item_photos_controller.ts` (hapus & ganti ke MinIO)
+- [ ] Tambah mekanisme presigned URL (Opsi A atau B)
+- [ ] Update frontend `ItemCard.jsx` untuk menggunakan URL baru
+- [ ] Tambah `#services/*` ke `package.json` imports jika belum ada (cek sudah ada: `"#services/*": "./app/services/*.js"`)
+- [ ] Test upload foto baru via API
+- [ ] Test tampil foto di frontend
+- [ ] Test hapus foto via API
+- [ ] (Opsional) Migrasi foto lama dari `public/uploads/` ke MinIO
+
+## File yang Perlu Diubah
+
+| File | Aksi |
+|------|------|
+| `backend/app/services/minio_service.ts` | **BUAT BARU** — Service untuk interaksi MinIO |
+| `backend/app/controllers/items_controller.ts` | **UBAH** — Upload foto ke MinIO |
+| `backend/app/controllers/item_photos_controller.ts` | **UBAH** — Hapus foto dari MinIO |
+| `backend/start/routes.ts` | **UBAH** (jika Opsi A) — Tambah endpoint URL foto |
+| `frontend/src/views/apps/items/ItemCard.jsx` | **UBAH** — Akses foto via presigned URL |
+
+## Referensi
+
+- [MinIO JavaScript SDK Documentation](https://min.io/docs/minio/linux/developers/javascript/API.html)
+- [AdonisJS File Upload Documentation](https://docs.adonisjs.com/guides/file-uploads)
+- Bucket name: `shefly-password`
+- MinIO endpoint: `server.hafiyyanabdulaziz.my.id:9002`
+
+## Catatan Penting
+
+1. **Jangan hapus `@adonisjs/static`** dari providers. Mungkin masih diperlukan untuk aset statis lain (CSS, JS, dll).
+2. **Format `photoUrl` di database berubah:**
+   - Lama: `/uploads/filename.jpg` (relative path ke public folder)
+   - Baru: `uploads/uuid.jpg` (MinIO object key, tanpa leading slash)
+3. **Presigned URL punya expiry time.** Default 7 hari. Jangan cache URL terlalu lama di frontend.
+4. **Error handling:** Selalu wrap operasi MinIO dalam try-catch. Jangan sampai gagal upload/hapus MinIO menyebabkan error 500 tanpa informasi yang jelas.


### PR DESCRIPTION
This PR migrates photo storage from local filesystem to MinIO Object Storage. It includes:
1. MinioService for S3-compatible storage operations.
2. Updated Items and Photos controllers to handle MinIO uploads/deletions.
3. Presigned URL generation for secure photo access.
4. Fixed a frontend caching issue in Next.js where deleted/updated items wouldn't reflect changes immediately by adding cache: 'no-store' to server-side fetch calls.
5. Legacy support for photos still stored on local disk.