### PR TITLE
Simplify Add Folder Modal

### DIFF
--- a/frontend/src/views/apps/folders/AddFolderModal.jsx
+++ b/frontend/src/views/apps/folders/AddFolderModal.jsx
@@ -77,22 +77,6 @@ const AddFolderModal = ({ open, handleClose, onUpdate, folders, folderToEdit, de
             onChange={e => setName(e.target.value)}
             autoFocus
           />
-          <TextField
-            select
-            fullWidth
-            label='Parent Folder (Optional)'
-            value={parentId}
-            onChange={e => setParentId(e.target.value)}
-          >
-            <MenuItem value=''>Root</MenuItem>
-            {folders
-              .filter(f => f.id !== folderToEdit?.id) // Prevent self-parenting
-              .map(f => (
-                <MenuItem key={f.id} value={f.id}>
-                  {f.name}
-                </MenuItem>
-              ))}
-          </TextField>
         </div>
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
This PR removes the manual 'Parent Folder' selection from the Add New Folder modal. The parent folder is now automatically assigned based on the current directory context, improving the user experience by reducing manual input.